### PR TITLE
`window.Image` instead of bare `Image`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import React, { Component, PropTypes } from "react";
 export default class ReactImageFallback extends Component {
 	constructor(props) {
 		super(props);
-		this.displayImage = new Image();
+		this.displayImage = new window.Image();
 		this.state = {
 			imageSource: props.initialImage
 		};


### PR DESCRIPTION
helps my tests pass when using virtual-dom without an awkward workaround