### PR TITLE
Migrates deprecated React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "testdouble": "^1.2.0"
   },
   "dependencies": {
-    "filter-invalid-dom-props": "1.0.0"
+    "filter-invalid-dom-props": "1.0.0",
+    "prop-types": "^15.5.10"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import PropTypes from 'prop-types'
+import React, { Component } from "react";
 import filterInvalidDOMProps from "filter-invalid-dom-props";
 
 export default class ReactImageFallback extends Component {


### PR DESCRIPTION
Moves from React.PropTypes to "prop-types" module