### PR TITLE
src should be nullable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types'
+import PropTypes from "prop-types"
 import React, { Component } from "react";
 import filterInvalidDOMProps from "filter-invalid-dom-props";
 
@@ -27,9 +27,10 @@ export default class ReactImageFallback extends Component {
 		this.displayImage.onload = null;
 		this.displayImage = null;
 	}
-	
+
 	setDisplayImage({ image, fallbacks }) {
-		const imagesArray = [image].concat(fallbacks);
+		const fallbacksArray = Array.isArray(fallbacks) ? fallbacks : [fallbacks];
+		const imagesArray = image ? [image].concat(fallbacksArray) : fallbacksArray;
 		this.displayImage.onerror = () => {
 			if (imagesArray.length > 2 && typeof imagesArray[1] === "string") {
 				const updatedFallbacks = imagesArray.slice(2);
@@ -69,7 +70,7 @@ export default class ReactImageFallback extends Component {
 ReactImageFallback.displayName = "ReactImageFallback";
 
 ReactImageFallback.propTypes = {
-	src: PropTypes.string.isRequired,
+	src: PropTypes.string,
 	fallbackImage: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.array]).isRequired,
 	initialImage: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 	onLoad: PropTypes.func,

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,16 @@ test("properly fallback to fallbackImage when src is broken", (assert) => {
 	}, 800);
 });
 
+test("properly fallback to fallbackImage when src is falsy", (assert) => {
+	const component = <ReactImageFallback fallbackImage={fallbackImage} />;
+	const rendered = renderComponent(component);
+	//use setTimeout so async action of state being set can happen
+	setTimeout(() => {
+		assert.ok(rendered.state.imageSource === fallbackImage, "state is properly set to fallback image");
+		ReactDOM.unmountComponentAtNode(node);
+		assert.end();
+	}, 800);
+});
 
 test("src is correctly rendered in dom when src prop is a valid image", (assert) => {
 	const component = <ReactImageFallback src={srcImage} fallbackImage={fallbackImage} />;


### PR DESCRIPTION
How I use this component:

If `this.props.maybeNull` isn't `null` but it fails to get the image, it falls back to `brokenImage`

If `this.props.maybeNull` is `null`, it also falls back to `brokenImage`

```js
src={this.props.maybeNull}
fallbackImage={brokenImage}
```

Alternative I could do

```js
src={this.props.maybeNull || brokenImage}
fallbackImage={brokenImage}
```

But this is a lot more verbose and `fallbackImage` (by name) should take care of both use-cases IMO.

Do you think this is a valid use-case? If not, what do you think should be the right pattern?