### PR TITLE
fallbackImage might contain a falsy value

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A callback called if initial image loads successfully, will be called with succe
 A callback called if initial image load fails, will be called with failing image url.
 
 #### `spread props`
-This component also utilizes jsx spread attributes to pass along custom image attributes such as alt tags and className. Only valid dom props will be spread to the image tag. 
+This component also utilizes jsx spread attributes to pass along custom image attributes such as alt tags and className. Only valid dom props will be spread to the image tag.
 
 ### Use
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "eslint": "^1.2.0",
     "eslint-plugin-react": "^3.1.0",
     "react": "^15",
-    "react-addons-test-utils": "^15",
     "react-dom": "^15",
     "smokestack": "^3.4.1",
     "tap-closer": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,7 @@ export default class ReactImageFallback extends Component {
 	}
 
 	setDisplayImage({ image, fallbacks }) {
-		const fallbacksArray = Array.isArray(fallbacks) ? fallbacks : [fallbacks];
-		const imagesArray = image ? [image].concat(fallbacksArray) : fallbacksArray;
+		const imagesArray = [image].concat(fallbacks).filter(fallback => !!fallback)
 		this.displayImage.onerror = () => {
 			if (imagesArray.length > 2 && typeof imagesArray[1] === "string") {
 				const updatedFallbacks = imagesArray.slice(2);
@@ -38,7 +37,7 @@ export default class ReactImageFallback extends Component {
 				return;
 			}
 			this.setState({
-				imageSource: imagesArray[1]
+				imageSource: imagesArray[1] || null
 			}, () => {
 				if (this.props.onError) {
 					this.props.onError(this.props.src);
@@ -54,7 +53,18 @@ export default class ReactImageFallback extends Component {
 				}
 			});
 		};
-		this.displayImage.src = imagesArray[0];
+		if (typeof imagesArray[0] === "string") {
+			this.displayImage.src = imagesArray[0];
+		}
+		else {
+			this.setState({
+				imageSource: imagesArray[0]
+			}, () => {
+				if (this.props.onLoad) {
+					this.props.onLoad(imagesArray[0]);
+				}
+			});
+		}
 	}
 
 	render() {

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import TestUtils from "react-addons-test-utils";
+import TestUtils from "react-dom/test-utils";
 import test from "tape-catch";
 import td from 'testdouble';
 import ReactImageFallback from "../lib";
@@ -26,7 +26,7 @@ test("properly set state to src image", (assert) => {
 		assert.ok(rendered.state.imageSource === srcImage, "state is properly set to src image");
 		ReactDOM.unmountComponentAtNode(node);
 		assert.end();
-	}, 500);
+	}, 1500);
 });
 
 test("properly fallback to fallbackImage when src is broken", (assert) => {
@@ -37,7 +37,7 @@ test("properly fallback to fallbackImage when src is broken", (assert) => {
 		assert.ok(rendered.state.imageSource === fallbackImage, "state is properly set to fallback image");
 		ReactDOM.unmountComponentAtNode(node);
 		assert.end();
-	}, 800);
+	}, 1000);
 });
 
 test("properly fallback to fallbackImage when src is falsy", (assert) => {
@@ -46,6 +46,27 @@ test("properly fallback to fallbackImage when src is falsy", (assert) => {
 	//use setTimeout so async action of state being set can happen
 	setTimeout(() => {
 		assert.ok(rendered.state.imageSource === fallbackImage, "state is properly set to fallback image");
+		ReactDOM.unmountComponentAtNode(node);
+		assert.end();
+	}, 1000);
+});
+
+test("properly fallback to fallbackImage when fallbackImage contains a falsy value", (assert) => {
+	const component = <ReactImageFallback src='http://brokenimage.com' fallbackImage={[undefined, fallbackImage]} />;
+	const rendered = renderComponent(component);
+	//use setTimeout so async action of state being set can happen
+	setTimeout(() => {
+		assert.ok(rendered.state.imageSource === fallbackImage, "state is properly set to fallback image");
+		ReactDOM.unmountComponentAtNode(node);
+		assert.end();
+	}, 800);
+});
+
+test("should not blow up if fallbackImage doesn't contain a truthy value", (assert) => {
+	const component = <ReactImageFallback src='http://brokenimage.com' fallbackImage={[undefined, null]} />;
+	const rendered = renderComponent(component);
+	//use setTimeout so async action of state being set can happen
+	setTimeout(() => {
 		ReactDOM.unmountComponentAtNode(node);
 		assert.end();
 	}, 800);
@@ -104,7 +125,7 @@ test("onError function is called on failed src load if provided", (assert) => {
 		assert.ok(td.verify(onError("http://brokenimage.com")) === undefined, "onError called with srcImage");
 		ReactDOM.unmountComponentAtNode(node);
 		assert.end();
-	}, 800);
+	}, 1000);
 });
 
 test("should allow react element as fallback", (assert) => {
@@ -117,7 +138,7 @@ test("should allow react element as fallback", (assert) => {
 		assert.ok(dom.className === "div-class", "uses div as fallback");
 		ReactDOM.unmountComponentAtNode(node);
 		assert.end();
-	}, 800);
+	}, 1000);
 });
 
 test("should allow react element as initialImage", (assert) => {
@@ -146,7 +167,7 @@ test("should allow array of fallbacks", (assert) => {
 		assert.ok(dom.src === fallbackImage, "rendered image has fallbackImage prop as src");
 		ReactDOM.unmountComponentAtNode(node);
 		assert.end();
-	}, 800);
+	}, 3000);
 });
 
 test("should allow array of fallbacks and should stop when hitting react element", (assert) => {
@@ -160,5 +181,19 @@ test("should allow array of fallbacks and should stop when hitting react element
 		assert.ok(dom.className === "div-class", "uses div as fallback");
 		ReactDOM.unmountComponentAtNode(node);
 		assert.end();
-	}, 800);
+	}, 3000);
+});
+
+test("should allow array of fallbacks and should stop when hitting react element and src is falsy", (assert) => {
+	const fallbackElement = <div className="div-class">~**~</div>
+	const fallbacks = [fallbackElement, fallbackImage];
+	const component = <ReactImageFallback fallbackImage={fallbacks} />;
+	const rendered = renderComponent(component);
+	//use setTimeout so async action of state being set can happen
+	setTimeout(() => {
+		const dom = TestUtils.findRenderedDOMComponentWithTag(rendered, "div");
+		assert.ok(dom.className === "div-class", "uses div as fallback");
+		ReactDOM.unmountComponentAtNode(node);
+		assert.end();
+	}, 3000);
 });


### PR DESCRIPTION
```js
<ReactImageFallback
	src="my-image.png"
	fallbackImage={[nullable, "my-backup.png"]}
/>
```
If `nullable` is `undefined`, it throws a very unfriendly error: `ReactImageFallback.render(): A valid React element (or null) must be returned. You may have returned undefined, an array or some other invalid object.`

If `nullable` is `null`, I don't think most users wanna stop right there but fallback to `"my-backup.png"`