### PR TITLE
can use initial image timeout to timeout inital image before shows up

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ A string representing the image you want to fallback to if your primary image is
 #### `initialImage`
 The image to show before your `src` or `fallbackImage` load. Can optionally be passed in as a react element.
 
+#### `initialTimeout`
+timeout in millisecond before to show initialImage. Default is null which should initialImage immediately
+
 #### `onLoad`
 A callback called if initial image loads successfully, will be called with successful image url.
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,22 +6,41 @@ export default class ReactImageFallback extends Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			imageSource: props.initialImage
+			imageSource: null
 		};
 		this.setDisplayImage = this.setDisplayImage.bind(this);
+		this.handleInitialTimeout = this.handleInitialTimeout.bind(this);
+		this.isLoaded = false;
+	}
+
+	handleInitialTimeout() {
+		if (this.props.initialTimeout && this.props.initialTimeout > 0) {
+			setTimeout(() => {
+				if (!this.isLoaded) {
+					this.setState({
+						imageSource: this.props.initialImage
+					})
+				}
+			}, this.props.initialTimeout);
+		}
+		else {
+			this.setState({
+				imageSource: this.props.initialImage
+			});
+		}
 	}
 
 	componentDidMount() {
+		this.handleInitialTimeout();
 		this.displayImage = new window.Image();
 		this.setDisplayImage({ image: this.props.src, fallbacks: this.props.fallbackImage });
 	}
 
 	componentWillReceiveProps(nextProps) {
 		if (nextProps.src !== this.props.src) {
+			this.isLoaded = false;
 			if (nextProps.initialImage) {
-				this.setState({
-					imageSource: nextProps.initialImage
-				});
+				this.handleInitialTimeout();
 			}
 			this.setDisplayImage({ image: nextProps.src, fallbacks: nextProps.fallbackImage });
 		}
@@ -43,6 +62,7 @@ export default class ReactImageFallback extends Component {
 				this.setDisplayImage({ image: imagesArray[1], fallbacks: updatedFallbacks });
 				return;
 			}
+			this.isLoaded = true;
 			this.setState({
 				imageSource: imagesArray[1] || null
 			}, () => {
@@ -52,6 +72,7 @@ export default class ReactImageFallback extends Component {
 			});
 		};
 		this.displayImage.onload = () => {
+			this.isLoaded = true;
 			this.setState({
 				imageSource: imagesArray[0]
 			}, () => {
@@ -91,7 +112,8 @@ ReactImageFallback.propTypes = {
 	fallbackImage: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.array]).isRequired,
 	initialImage: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 	onLoad: PropTypes.func,
-	onError: PropTypes.func
+	onError: PropTypes.func,
+	initialTimeout: PropTypes.number
 };
 
 ReactImageFallback.defaultProps = {

--- a/test/index.js
+++ b/test/index.js
@@ -197,3 +197,21 @@ test("should allow array of fallbacks and should stop when hitting react element
 		assert.end();
 	}, 3000);
 });
+
+
+test("should not show initialImage when initial timeout is highenough", (assert) => {
+	const initial = <div className="div-class">~**~</div>
+	const component = (
+		<ReactImageFallback
+			src="http://brokenimage.com"
+			fallbackImage="http://brokenimage.com"
+			initialImage={initial}
+			initialTimeout={100000}
+		/>
+	);
+	const rendered = renderComponent(component);
+	const divsTag = TestUtils.scryRenderedDOMComponentsWithTag(rendered, "div");
+	assert.ok(divsTag.length === 0, "shouldn't show initial image before timeout");
+	ReactDOM.unmountComponentAtNode(node);
+	assert.end();
+});


### PR DESCRIPTION
in some cases we don't want to show initial image immediately if the loading is fast enough.