### PR TITLE
I've created TypeScript definitions for react-image-fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-[![TypeScript definitions on DefinitelyTyped](https://definitelytyped.org/badges/standard.svg)](http://definitelytyped.org)
-
 # React Image Fallback
 
 React Image Fallback exists for those times that you're just not sure an image will be there. See a simple demo <a href="http://socialtables.github.io/react-image-fallback/demo/">here</a>
 
-[![Circle CI](https://circleci.com/gh/socialtables/react-image-fallback.svg?style=svg)](https://circleci.com/gh/socialtables/react-image-fallback)
+[![Circle CI](https://circleci.com/gh/socialtables/react-image-fallback.svg?style=svg)](https://circleci.com/gh/socialtables/react-image-fallback) [![TypeScript definitions on DefinitelyTyped](https://definitelytyped.org/badges/standard.svg)](http://definitelytyped.org)
 
 ### Install
 ` npm install react-image-fallback`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![TypeScript definitions on DefinitelyTyped](https://definitelytyped.org/badges/standard.svg)](http://definitelytyped.org)
+
 # React Image Fallback
 
 React Image Fallback exists for those times that you're just not sure an image will be there. See a simple demo <a href="http://socialtables.github.io/react-image-fallback/demo/">here</a>


### PR DESCRIPTION
Hi, I've written Typescript definitions for the react-image-fallback component. You can find the typings package [here](https://www.npmjs.com/package/@types/react-image-fallback). Hence I thought it would be useful for readers of your ReadMe to know this via a badge.

Note that these typings should show up [here ](https://microsoft.github.io/TypeSearch/) very soon.