### PR TITLE
Remove html attributes dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2353,14 +2353,6 @@
         "repeat-string": "^1.5.2"
       }
     },
-    "filter-invalid-dom-props": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/filter-invalid-dom-props/-/filter-invalid-dom-props-1.0.0.tgz",
-      "integrity": "sha1-RNDQMGZXslhOBPcdQoIp67mGfKE=",
-      "requires": {
-        "html-attributes": "1.1.0"
-      }
-    },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -3252,11 +3244,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
       "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
-    },
-    "html-attributes": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/html-attributes/-/html-attributes-1.1.0.tgz",
-      "integrity": "sha1-ggJ6T6x6YHDqbBjMOIauoY1t6gk="
     },
     "htmlescape": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "testdouble": "^1.2.0"
   },
   "dependencies": {
-    "filter-invalid-dom-props": "1.0.0",
     "prop-types": "^15.5.10"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types"
 import React, { Component } from "react";
-import filterInvalidDOMProps from "filter-invalid-dom-props";
 
 export default class ReactImageFallback extends Component {
 	constructor(props) {
@@ -96,10 +95,16 @@ export default class ReactImageFallback extends Component {
 	}
 
 	render() {
+                // don't pass through our own props, but do pass any other props supplied to the image
+                let imgProps = {};
+                Object.keys(this.props).forEach((key, index) => {
+                    if(!(key in ReactImageFallback.propTypes))
+                       imgProps[key] = this.props[key];
+                });
 		return (
 			typeof this.state.imageSource === "string"
 			?
-			<img {...filterInvalidDOMProps(this.props)} src={this.state.imageSource} />
+			<img {...imgProps} src={this.state.imageSource} />
 			:
 			this.state.imageSource
 		);


### PR DESCRIPTION
This was using `filter-invalid-dom-props` to decide what props to pass through to the wrapped `img` tag. However, that project depends on `html-attributes` which is under the *Open Works License* - a worthy license, but not a common one, and so may require legal review for various projects.

This change rather just filters out the properties of the component itself - and passes others through, just as you could when using `img` directly